### PR TITLE
Expose raw proplist to report_mf callback.

### DIFF
--- a/src/ehmon.erl
+++ b/src/ehmon.erl
@@ -12,6 +12,7 @@
           ,update/1
           ,info_report/1
           ,stdout_report/1
+          ,raw_report/1
           ,report/1
         ]).
 
@@ -37,8 +38,8 @@ info_report(Iolist) ->
 stdout_report(Iolist) ->
     io:format(standard_io, "ehmon_report ~s~n", [Iolist]).
 
--spec report(#state{}) -> iolist().
-report(State) ->
+-spec raw_report(#state{}) -> [{atom(), term()}].
+raw_report(State) ->
     Stats = [{context_switches,
               element(1, erlang:statistics(context_switches))},
               {run_queue, erlang:statistics(run_queue)}],
@@ -56,7 +57,11 @@ report(State) ->
                               false -> 1400;
                               MaxEtsTabsS -> list_to_integer(MaxEtsTabsS)
                           end}],
-    report_string(Extra ++ Mem ++ Stats ++ Info).
+    Extra ++ Mem ++ Stats ++ Info.
+
+-spec report(#state{}) -> iolist().
+report(State) ->
+    report_string(raw_report(State)).
 
 %%====================================================================
 %% Internal functions

--- a/src/ehmon_report_srv.erl
+++ b/src/ehmon_report_srv.erl
@@ -84,8 +84,8 @@ code_change(_OldVsn, State, _Extra) ->
 do_report(RState) ->
     try
         case ehmon_app:config(report_mf, {ehmon, send_report}) of
-            {M, F, raw} -> erlang:apply(M, F, [ehmon:raw_report(RState)]);
-            {M, F} -> erlang:apply(M, F, [ehmon:report(RState)])
+            {M, F, raw} -> M:F(ehmon:raw_report(RState));
+            {M, F} -> M:F(ehmon:report(RState))
         end
     catch
         Class:Err ->

--- a/src/ehmon_report_srv.erl
+++ b/src/ehmon_report_srv.erl
@@ -83,8 +83,10 @@ code_change(_OldVsn, State, _Extra) ->
 
 do_report(RState) ->
     try
-        {M, F} = ehmon_app:config(report_mf, {ehmon, send_report}),
-        erlang:apply(M, F, [ehmon:report(RState)])
+        case ehmon_app:config(report_mf, {ehmon, send_report}) of
+            {M, F, raw} -> erlang:apply(M, F, [ehmon:raw_report(RState)]);
+            {M, F} -> erlang:apply(M, F, [ehmon:report(RState)])
+        end
     catch
         Class:Err ->
             ?ERR("class=~p err=~p stack=\"~p\"",


### PR DESCRIPTION
If the report_mf app config value is set to a tuple of {M,F,raw}, then
it will be called with the raw proplist of values rather than the
stringified version. This will allow consumers to do things like emit
lines in l2met-friendly formats.

I'm not totally sure about this method of indicating you want access to
the raw values; maybe a separate config should be used?
